### PR TITLE
chore: 로컬 전용 env의 이름을 .env로 수정

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-# TODO: 추후 환경 별 env 정리 및 gitignore 예정
+# Local 전용 환경 변수
 MYSQL_ROOT_PASSWORD=root
 MYSQL_DATABASE=HomersDB
 MYSQL_USER=gomdol

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ lerna-debug.log*
 !.vscode/extensions.json
 
 # dotenv environment variable files
-.env
 .env.development.local
 .env.test.local
 .env.production.local

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
-    "start:local": "dotenv -e .env.local nest start --watch",
+    "start:local": "nest start --watch",
     "start:dev": "dotenv -e .env.development nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
@@ -21,7 +21,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "docker:up": "docker-compose up -d",
     "docker:down": "docker-compose -f docker-compose.yml down -v",
-    "prisma:studio:local": "dotenv -e .env.local prisma studio"
+    "prisma:studio": "prisma studio"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { AuthModule } from './auth/auth.module';
 @Module({
   imports: [
     ConfigModule.forRoot({
+      envFilePath: process.env.NODE_ENV ? `.env.${process.env.NODE_ENV}` : '.env',
       expandVariables: true,
       isGlobal: true,
     }),


### PR DESCRIPTION
### 🔍️ PR을 통해 해결하려는 문제
- 기존에 로컬에서 사용하는 env 파일 이름이 .env.local 이었는데, prisma studio 등의 기능에서 적용이 안되는 문제가 있었어요.

### ✨ PR에서 변경된 사항
- 로컬에서의 .env 파일 이름이 .env.local 이었는데, .env로 변경했어요.

적용할 계획
```
.env: 로컬 전용 env 파일
.env.development: 개발 서버 전용 env 파일 (근데 아마 안쓸듯..)
.env.production: 실제 배포 환경 전용 env 파일
```