### PR TITLE
feat: 코멘트(댓글) 작성/삭제 API 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { UsersModule } from './users/users.module';
 import { ImageModule } from './image/image.module';
 import { FollowModule } from './follow/follow.module';
 import { SettingsModule } from './settings/settings.module';
+import { CommentsModule } from './comments/comments.module';
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { SettingsModule } from './settings/settings.module';
     ImageModule,
     FollowModule,
     SettingsModule,
+    CommentsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/comments/comments.controller.spec.ts
+++ b/src/comments/comments.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CommentsController } from './comments.controller';
+import { CommentsService } from './comments.service';
+
+describe('CommentsController', () => {
+  let controller: CommentsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CommentsController],
+      providers: [CommentsService],
+    }).compile();
+
+    controller = module.get<CommentsController>(CommentsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/comments/comments.controller.ts
+++ b/src/comments/comments.controller.ts
@@ -1,0 +1,7 @@
+import { Controller } from '@nestjs/common';
+import { CommentsService } from './comments.service';
+
+@Controller('comments')
+export class CommentsController {
+  constructor(private readonly commentsService: CommentsService) {}
+}

--- a/src/comments/comments.controller.ts
+++ b/src/comments/comments.controller.ts
@@ -1,7 +1,30 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Post, Body, Delete, UseGuards, Req } from '@nestjs/common';
 import { CommentsService } from './comments.service';
+import { CreateCommentDto } from './dto/create-comment.dto';
+import { JwtAuthGuard } from '../auth/guard/jwt-auth.guard';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 
+@ApiTags('comments')
 @Controller('comments')
+@UseGuards(JwtAuthGuard)
 export class CommentsController {
   constructor(private readonly commentsService: CommentsService) {}
+
+  @ApiOperation({
+    summary: '특정 포스트에 댓글 달기',
+    description: '특정 포스트에 댓글을 작성합니다.',
+  })
+  @Post('create')
+  create(@Body() createCommentDto: CreateCommentDto, @Req() req) {
+    return this.commentsService.createComment(createCommentDto, req.user.id);
+  }
+
+  @ApiOperation({
+    summary: '특정 포스트에 작성한 내 댓글 지우기',
+    description: '특정 포스트에 작성한 내 댓글을 삭제합니다.',
+  })
+  @Delete('delete')
+  delete(@Body('id') id: string, @Req() req) {
+    return this.commentsService.deleteComment(id, req.user.id);
+  }
 }

--- a/src/comments/comments.module.ts
+++ b/src/comments/comments.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { CommentsService } from './comments.service';
+import { CommentsController } from './comments.controller';
+
+@Module({
+  controllers: [CommentsController],
+  providers: [CommentsService],
+})
+export class CommentsModule {}

--- a/src/comments/comments.module.ts
+++ b/src/comments/comments.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { CommentsService } from './comments.service';
 import { CommentsController } from './comments.controller';
+import { PrismaService } from 'src/prisma.service';
 
 @Module({
   controllers: [CommentsController],
-  providers: [CommentsService],
+  providers: [CommentsService, PrismaService],
 })
 export class CommentsModule {}

--- a/src/comments/comments.service.spec.ts
+++ b/src/comments/comments.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CommentsService } from './comments.service';
+
+describe('CommentsService', () => {
+  let service: CommentsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CommentsService],
+    }).compile();
+
+    service = module.get<CommentsService>(CommentsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class CommentsService {}

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -1,4 +1,41 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+import { CreateCommentDto } from './dto/create-comment.dto';
 
 @Injectable()
-export class CommentsService {}
+export class CommentsService {
+  constructor(private prisma: PrismaService) {}
+
+  async createComment(createCommentDto: CreateCommentDto, userId: string) {
+    const { comment, postId } = createCommentDto;
+
+    // 1. 게시글부터 찾자
+    const post = await this.prisma.post.findUnique({ where: { id: +postId } });
+    // 1.1. 못 찾으면 NotFoundException을 던지자
+    if (!post) {
+      throw new NotFoundException(`Post with ID ${postId} not found`);
+    }
+    //TODO 2. 프리즈마로 comment 모델에 새 데이터를 생성하자
+    return `
+      This action adds a new comment by userId: ${userId}
+      new comment content: ${comment}
+    `;
+  }
+
+  async deleteComment(id: string, userId: string) {
+    // 1. 받은 코멘트 id로 코멘트를 찾자
+    const comment = await this.prisma.comment.findUnique({
+      where: { id: +id },
+    });
+    // 1.1. 코멘트를 못 찾으면 NotFoundException을 던지자
+    if (!comment) {
+      throw new NotFoundException(`Comment with ID ${id} not found`);
+    }
+    // 1.2. 본인의 코멘트가 아니면 NotFoundException을 던지자
+    if (comment.userId !== +userId) {
+      throw new NotFoundException(`You can only delete your own comments`);
+    }
+    //TODO 2. 프리즈마로 comment 모델에 데이터를 제거하자
+    return `This action removes a ${id} comment by user ${userId}`;
+  }
+}

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -15,11 +15,20 @@ export class CommentsService {
     if (!post) {
       throw new NotFoundException(`Post with ID ${postId} not found`);
     }
+
     //TODO 2. 프리즈마로 comment 모델에 새 데이터를 생성하자
-    return `
-      This action adds a new comment by userId: ${userId}
-      new comment content: ${comment}
-    `;
+    try {
+      const newComment = await this.prisma.comment.create({
+        data: {
+          comment,
+          postId: +postId,
+          userId: +userId,
+        },
+      });
+      return newComment;
+    } catch (error) {
+      throw new Error('댓글 생성에 실패하였습니다.');
+    }
   }
 
   async deleteComment(id: string, userId: string) {
@@ -36,6 +45,13 @@ export class CommentsService {
       throw new NotFoundException(`You can only delete your own comments`);
     }
     //TODO 2. 프리즈마로 comment 모델에 데이터를 제거하자
-    return `This action removes a ${id} comment by user ${userId}`;
+    try {
+      await this.prisma.comment.delete({
+        where: { id: +id },
+      });
+      return `댓글(${id})이 성공적으로 삭제되었습니다.`;
+    } catch (error) {
+      throw new Error('댓글 삭제에 실패하였습니다.');
+    }
   }
 }

--- a/src/comments/dto/create-comment.dto.ts
+++ b/src/comments/dto/create-comment.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateCommentDto {
+  @IsNotEmpty()
+  @IsString()
+  comment: string;
+
+  @IsNotEmpty()
+  @IsString()
+  postId: string;
+}


### PR DESCRIPTION
### 🔍️ PR을 통해 해결하려는 문제

>어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
>일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요

- #31 

- [x] **Comments API 구현하기**
  - [x] 댓글 작성 기능
  - [x] 댓글 삭제 기능

### ✨ PR에서 변경된 사항
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
* `POST: comments/create`와 `DELETE: comments/delete` API로 댓글 작성과 삭제가 가능합니다.


### 🙏 PR에서 신경써서 보아야 할 부분
> 개발 과정에서 다른 분들의 의견은 어떠한지 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요
* 문제 발생 시 Exception 처리나 Error 처리에 대한 컨벤션 혹은 전통적 방식의 처리법이 정리되어 있을 필요가 있다고 느껴요.
* 지금은 그냥 Error를 던지는 형태로 되어 있는데, 어떤 코드에서는 HttpException을, 어떤 곳에서는 InternalServerException을 던지고 있는데 이 부분이 궁금해요
* 댓글 작성인 **create-comments** DTO는 존재하는데, 삭제에는 id값만 필요해서 굳이 dto 파일을 만들지 않았어요.
* 테스트 결과 작성 및 삭제 베스트 케이스에선 잘 작동해요 

### 📝 Assignee를 위한 CheckList
