### PR TITLE
feat: 좋아요 및 좋아요 취소 API 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { UsersModule } from './users/users.module';
 import { ImageModule } from './image/image.module';
 import { FollowModule } from './follow/follow.module';
 import { SettingsModule } from './settings/settings.module';
+import { LikesModule } from './likes/likes.module';
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { SettingsModule } from './settings/settings.module';
     ImageModule,
     FollowModule,
     SettingsModule,
+    LikesModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/likes/dto/create-like.dto.ts
+++ b/src/likes/dto/create-like.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateLikeDto {
+  @IsNotEmpty()
+  @IsString()
+  postId: string;
+}

--- a/src/likes/entities/like.entity.ts
+++ b/src/likes/entities/like.entity.ts
@@ -1,0 +1,1 @@
+export class Like {}

--- a/src/likes/likes.controller.spec.ts
+++ b/src/likes/likes.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LikesController } from './likes.controller';
+import { LikesService } from './likes.service';
+
+describe('LikesController', () => {
+  let controller: LikesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [LikesController],
+      providers: [LikesService],
+    }).compile();
+
+    controller = module.get<LikesController>(LikesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/likes/likes.controller.ts
+++ b/src/likes/likes.controller.ts
@@ -1,0 +1,30 @@
+import { Controller, Post, Body, Delete, UseGuards, Req } from '@nestjs/common';
+import { LikesService } from './likes.service';
+import { CreateLikeDto } from './dto/create-like.dto';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from 'src/auth/guard/jwt-auth.guard';
+
+@ApiTags('likes')
+@Controller('likes')
+@UseGuards(JwtAuthGuard)
+export class LikesController {
+  constructor(private readonly likesService: LikesService) {}
+
+  @ApiOperation({
+    summary: '특정 포스트 좋아요',
+    description: '특정 포스트에 좋아요합니다.',
+  })
+  @Post('create')
+  create(@Body() createLikeDto: CreateLikeDto, @Req() req) {
+    return this.likesService.createLike(createLikeDto, req.user.id);
+  }
+
+  @ApiOperation({
+    summary: '특정 포스트 좋아요 취소',
+    description: '특정 포스트에 좋아요한 것을 취소합니다.',
+  })
+  @Delete('delete')
+  remove(@Body('id') id: string, @Req() req) {
+    return this.likesService.deleteLike(+id, req.user.id);
+  }
+}

--- a/src/likes/likes.module.ts
+++ b/src/likes/likes.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { LikesService } from './likes.service';
+import { LikesController } from './likes.controller';
+import { PrismaService } from 'src/prisma.service';
+
+@Module({
+  controllers: [LikesController],
+  providers: [LikesService, PrismaService],
+})
+export class LikesModule {}

--- a/src/likes/likes.service.spec.ts
+++ b/src/likes/likes.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LikesService } from './likes.service';
+
+describe('LikesService', () => {
+  let service: LikesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [LikesService],
+    }).compile();
+
+    service = module.get<LikesService>(LikesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/likes/likes.service.ts
+++ b/src/likes/likes.service.ts
@@ -1,0 +1,71 @@
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { CreateLikeDto } from './dto/create-like.dto';
+import { PrismaService } from 'src/prisma.service';
+
+@Injectable()
+export class LikesService {
+  constructor(private prisma: PrismaService) {}
+
+  async createLike(createLikeDto: CreateLikeDto, userId: string) {
+    const { postId } = createLikeDto;
+
+    const post = await this.prisma.post.findUnique({
+      where: { id: +postId },
+    });
+
+    if (!post) {
+      throw new NotFoundException(`Post with ID ${postId} not found`);
+    }
+
+    const alreadyLike = this.prisma.like.findFirst({
+      where: {
+        userId: +userId,
+        postId: +postId,
+      },
+    });
+
+    if (alreadyLike) {
+      throw new ConflictException('You have already liked this post');
+    }
+
+    try {
+      const newLike = await this.prisma.like.create({
+        data: {
+          userId: +userId,
+          postId: +postId,
+        },
+      });
+      return newLike;
+    } catch (error) {
+      throw new Error('좋아요에 실패하였습니다.');
+    }
+  }
+
+  async deleteLike(id: number, userId: string) {
+    const like = await this.prisma.like.findUnique({
+      where: { id },
+    });
+
+    if (!like) {
+      throw new NotFoundException(`Like with ID ${id} not found`);
+    }
+
+    if (like.userId !== +userId) {
+      throw new UnauthorizedException(`You can only delete your own likes`);
+    }
+
+    try {
+      await this.prisma.like.delete({
+        where: { id },
+      });
+      return `좋아요(${id})가 성공적으로 취소되었습니다.`;
+    } catch (error) {
+      throw new Error('좋아요 취소에 실패하였습니다.');
+    }
+  }
+}

--- a/src/likes/likes.service.ts
+++ b/src/likes/likes.service.ts
@@ -22,7 +22,7 @@ export class LikesService {
       throw new NotFoundException(`Post with ID ${postId} not found`);
     }
 
-    const alreadyLike = this.prisma.like.findFirst({
+    const alreadyLike = await this.prisma.like.findFirst({
       where: {
         userId: +userId,
         postId: +postId,


### PR DESCRIPTION
### 🔍️ PR을 통해 해결하려는 문제

>어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
>일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요

* #35 

- [x] Likes API 구현하기
  - [x] post에 좋아요 남기기
  - [x] post에 좋아요 취소하기

### ✨ PR에서 변경된 사항
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
* `POST: likes/create`와 `DELETE: likes/delete` API로 좋아요와 좋아요 취소가 가능합니다.


### 🙏 PR에서 신경써서 보아야 할 부분
> 개발 과정에서 다른 분들의 의견은 어떠한지 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요
* **이미 like되어 있는 post에는 좋아요를 할 수 없게 해야 하는 문제**
  * postId와 userId를 통해 좋아요하였는지 찾고(`alreadyLike`), 있다면 **ConflictException**을 던지도록 했습니다.
* **`동시성/트랜잭션`에 대해서**
  * 혹시 동시에 create/delete 요청을 많이 하면 어떻게 될지 궁금합니다. 어떻게 테스트할 수 있을까요?

### 📝 Assignee를 위한 CheckList
- [ ] 로그인하지 않은 상태에서 create, delete 요청해보기
- [ ] 로그인한 상태에서 토큰과 함께 create, delete 요청해보기
  - [ ] 존재하는 postId와 함께 create 요청해보기
  - [ ] 이미 like한 postId와 함께 create 요청해보기
  - [ ] 존재하지 않는 postId와 함께 create 요청해보기
  - [ ] 존재하는 id (like id)와 함께 delete 요청해보기
  - [ ] 이미 delete한 id (like id)와 함께 delete 요청해보기
  - [ ] 존재하지 않은 id (like id)와 함께 delete 요청해보기

